### PR TITLE
Allow reading and writing to open h5py.File objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ inplace:
 
 test: in
 	rm -f .coverage
-	$(pytest) h5io
+	$(PYTEST) h5io
 
 flake:
 	@if command -v flake8 > /dev/null; then \

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -112,18 +112,18 @@ def write_hdf5(fname, data, overwrite=False, compression=4,
     comp_kw = dict()
     if compression > 0:
         comp_kw = dict(compression='gzip', compression_opts=compression)
-    def _write(fid):
+    def _write(fid, cleanup_data):
         if title in fid:
             del fid[title]
-        cleanup_data = []
         _triage_write(title, data, fid, comp_kw, str(type(data)),
                       cleanup_data, slash=slash, title=title,
                       use_json=use_json)
+    cleanup_data = []
     if isinstance(fname, h5py.File):
-        _write(fname)
+        _write(fname, cleanup_data)
     else:
         with h5py.File(fname, mode=mode) as fid:
-            _write(fid)
+            _write(fid, cleanup_data)
 
     # Will not be empty if any extra data to be written
     for data in cleanup_data:

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -99,8 +99,9 @@ def write_hdf5(fname, data, overwrite=False, compression=4,
                     raise ValueError('overwrite must be "update" or a bool')
                 mode = 'a'
             elif not overwrite:
-                raise IOError('file "%s" exists, use overwrite=True to overwrite'
-                            % fname)
+                raise IOError(
+                    'file "%s" exists, use overwrite=True to overwrite' % fname
+                )
     elif isinstance(fname, h5py.File) and fname.mode == 'r':
         raise UnsupportedOperation('not writable')
     else:
@@ -110,6 +111,7 @@ def write_hdf5(fname, data, overwrite=False, compression=4,
     comp_kw = dict()
     if compression > 0:
         comp_kw = dict(compression='gzip', compression_opts=compression)
+
     def _write(fid, cleanup_data):
         if title in fid:
             del fid[title]
@@ -274,11 +276,14 @@ def read_hdf5(fname, title='h5io', slash='ignore'):
         if not op.isfile(fname):
             raise IOError('file "%s" not found' % fname)
     elif isinstance(fname, h5py.File) and fname.mode == 'w':
-        raise UnsupportedOperation('file must not be opened be opened with "w"')
+        raise UnsupportedOperation(
+            'file must not be opened be opened with "w"'
+        )
     else:
         raise ValueError('fname must be str or h5py.File')
     if not isinstance(title, str):
         raise ValueError('title must be a string')
+
     def _read(fid):
         if title not in fid:
             raise ValueError('no "%s" data found' % title)

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -8,6 +8,7 @@ import json
 import tempfile
 from shutil import rmtree
 from os import path as op
+from io import UnsupportedOperation
 
 import numpy as np
 

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -100,11 +100,8 @@ def write_hdf5(fname, data, overwrite=False, compression=4,
             elif not overwrite:
                 raise IOError('file "%s" exists, use overwrite=True to overwrite'
                             % fname)
-    elif isinstance(fname, h5py.File):
-        if fname.mode == 'r':
-            raise UnsupportedOperation('not writable')
-        if fname.mode == 'w' and not overwrite:
-            raise ValueError('file must be opened with "r+", if overwrite is False')
+    elif isinstance(fname, h5py.File) and fname.mode == 'r':
+        raise UnsupportedOperation('not writable')
     else:
         raise ValueError('fname must be str or h5py.File')
     if not isinstance(title, str):

--- a/h5io/tests/test_io.py
+++ b/h5io/tests/test_io.py
@@ -94,18 +94,19 @@ def test_h5_file_object(tmpdir):
     # test that reading/writing are unaffected
     with h5py.File(test_file_path, 'a') as test_file_obj:
         data = {'a': 42}
-        write_hdf5(test_file_path, data)
+        write_hdf5(test_file_obj, data)
         assert_equal(read_hdf5(test_file_obj), data)
     # test that wrong mode raises error
     with h5py.File(test_file_path, 'r') as test_file_obj:
-        pytest.raises(UnsupportedOperation,
-                      write_hdf5, fname=test_file_obj, data=1)
-    with h5py.File(test_file_path, 'w') as test_file_obj:
-        pytest.raises(UnsupportedOperation,
-                      read_hdf5, fname=test_file_obj)
-    with h5py.File(test_file_path, 'w') as test_file_obj:
-        pytest.raises(ValueError, write_hdf5, fname=test_file_obj, data=33,
-                      overwrite=False)
+        assert test_file_obj.mode == 'r'
+        with pytest.raises(UnsupportedOperation):
+            write_hdf5(test_file_obj, data=1)
+    # at least on some OSes (e.g., macOS) opening with mode='w' leads to
+    # test_file_obj.mode == 'r+', so let's skip this for now
+    # with h5py.File(test_file_path, 'w') as test_file_obj:
+    #     print(test_file_obj.mode)
+    #     with pytest.raises(UnsupportedOperation):
+    #         read_hdf5(test_file_obj)
 
 
 def test_hdf5_use_json(tmpdir):

--- a/h5io/tests/test_io.py
+++ b/h5io/tests/test_io.py
@@ -83,6 +83,28 @@ def test_hdf5(tmpdir):
     write_hdf5(test_file, 5, title='second', overwrite='update', compression=5)
     assert_equal(read_hdf5(test_file, title='second'), 5)
 
+def test_h5_file_object(tmpdir):
+    tempdir = str(tmpdir)
+    test_file_path = op.join(tempdir, 'test1.hdf5')
+    # test that wrong object type raises error
+    pytest.raises(ValueError, write_hdf5, fname=33, data=1)
+    # test that reading/writing are unaffected
+    with h5py.File(test_file_path, 'a') as test_file_obj:
+        data = {'a': 42}
+        write_hdf5(test_file_path, data)
+        assert_equal(read_hdf5(test_file_obj), data)
+    # test that wrong mode raises error
+    with h5py.File(test_file_path, 'r') as test_file_obj:
+        pytest.raises(UnsupportedOperation,
+                      write_hdf5, fname=test_file_obj, data=1)
+    with h5py.File(test_file_path, 'w') as test_file_obj:
+        pytest.raises(UnsupportedOperation,
+                      read_hdf5, fname=test_file_obj)
+    with h5py.File(test_file_path, 'w') as test_file_obj:
+        pytest.raises(ValueError,
+                      write_hdf5, fname=test_file_obj, data=33, overwrite=False)
+
+
 
 def test_hdf5_use_json(tmpdir):
     """Test HDF5 IO."""

--- a/h5io/tests/test_io.py
+++ b/h5io/tests/test_io.py
@@ -85,6 +85,7 @@ def test_hdf5(tmpdir):
     write_hdf5(test_file, 5, title='second', overwrite='update', compression=5)
     assert_equal(read_hdf5(test_file, title='second'), 5)
 
+
 def test_h5_file_object(tmpdir):
     tempdir = str(tmpdir)
     test_file_path = op.join(tempdir, 'test1.hdf5')
@@ -103,9 +104,8 @@ def test_h5_file_object(tmpdir):
         pytest.raises(UnsupportedOperation,
                       read_hdf5, fname=test_file_obj)
     with h5py.File(test_file_path, 'w') as test_file_obj:
-        pytest.raises(ValueError,
-                      write_hdf5, fname=test_file_obj, data=33, overwrite=False)
-
+        pytest.raises(ValueError, write_hdf5, fname=test_file_obj, data=33,
+                      overwrite=False)
 
 
 def test_hdf5_use_json(tmpdir):

--- a/h5io/tests/test_io.py
+++ b/h5io/tests/test_io.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
 from os import path as op
+from io import UnsupportedOperation
 import pytest
 
 import numpy as np
@@ -15,6 +16,7 @@ try:
 except ImportError:
     DataFrame = Series = None
 
+import h5py
 from h5io import (write_hdf5, read_hdf5,
                   object_diff, list_file_contents)
 


### PR DESCRIPTION
As discussed in #56.  I've added additional errors in case the file is opened with wrong modes. 