### PR TITLE
read_hdf(): Remove print of file mode

### DIFF
--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -284,7 +284,6 @@ def read_hdf5(fname, title='h5io', slash='ignore'):
             raise UnsupportedOperation(
                 'file must not be opened be opened with "w"'
             )
-        print(fname.mode)
     else:
         raise ValueError(f'fname must be str or h5py.File, got {type(fname)}')
     if not isinstance(title, str):


### PR DESCRIPTION
This came with https://github.com/h5io/h5io/pull/57 but I do not think it is necessary. 

@pmrv : Is it ok to remove this print statement? 