### PR TITLE
Throw error on writing objects with complex __getstate__

### DIFF
--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -370,8 +370,10 @@ def _triage_write(
             # values from __reduce__.  This requests for additional logic on
             # reconstruction of the object (documented in the pickle module)
             # that we don't implement currently in the _triage_read function
-            is_custom = reconstructor is not type(value) \
-                    and reconstructor.__module__ != "copyreg"
+            is_custom = (
+                reconstructor is not type(value)
+                and reconstructor.__module__ != "copyreg"
+            )
             if is_custom or len(additional) != 0:
                 raise TypeError(
                     "Object defines custom reconstructor, can't "

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -376,8 +376,8 @@ def _triage_write(
             )
             if is_custom or len(additional) != 0:
                 raise TypeError(
-                    "Object defines custom reconstructor, can't "
-                    "reconstruct data on read!"
+                    f"Can't write {repr(value)} at location {key}:\n"
+                    f"Class {class_type} defines custom reconstructor."
                 )
 
             sub_root = _create_titled_group(root, key, class_type)

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -367,8 +367,10 @@ def _triage_write(
             # reconstruction of the object (documented in the pickle module)
             # that we don't implement currently in the _triage_read function
             if reconstructor.__module__ != "copyreg" or len(additional) != 0:
-                raise TypeError("Object defines custom reconstructor, can't "
-                                "reconstruct data on read!")
+                raise TypeError(
+                    "Object defines custom reconstructor, can't "
+                    "reconstruct data on read!"
+                )
 
             sub_root = _create_titled_group(root, key, class_type)
 


### PR DESCRIPTION
The new functionality merged for 0.2.0 can fail if the objects written to HDF5 with `use_state=True` contain more complex pickling logic.  I came across this with this example.

```python
from ase.calculators.morse import MorsePotential
from h5io import read_hdf5, write_hdf5

calc = MorsePotential()

write_hdf5('state_test.h5', calc, title='test', use_state=True, overwrite=True)
read_hdf5('state_test.h5', title='test') # -> throws an error
```

The error is particularly annoying because writing seems to work, but reading fails.  The problem here is that `MorsePotential` (defined by ASE outside of my control) defines certain methods dynamically on the object instances, i.e. function/method objects end up in the objects `__dict__`.   When `_triage_read` tries to import the method object it obviously fails.

This could be worked around (after all `MorsePotential` can be pickled/unpickled just fine), but would require us to write more data to file (and think about the format and such).  To make it work generally we'd have to reimplement the whole pickle logic.  Instead I propose here as an easy solution to just fail with an error during writing.  

To detect whether we are attempting to store an object that we can't recreate I check whether the function returned by `__reduce__` is from the `copyreg` module, because all "plain" objects that I have seen return `copyreg._reconstructor` from their `__reduce__`, but this may be an implementation detail of CPython.  Alternatively one could check whether the return state is `None`, but since this was explicitly allowed in the previous code I've decided against that.