### PR TITLE
Store binary objects in HDF5

### DIFF
--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -267,7 +267,7 @@ def _triage_write(
             _create_titled_dataset(sub_root, "index", "ndarray", ma_index)
             _create_titled_dataset(sub_root, "data", "ndarray", ma_data)
     elif isinstance(value, np.void):
-        # Based on https://docs.h5py.org/en/stable/strings.html?highlight=binary#how-to-store-raw-binary-data
+        # Based on https://docs.h5py.org/en/stable/strings.html#how-to-store-raw-binary-data
         _create_titled_dataset(root, key, "void", value)
     elif sparse is not None and isinstance(value, sparse.csc_matrix):
         sub_root = _create_titled_group(root, key, "csc_matrix")
@@ -531,7 +531,7 @@ def _triage_read(node, slash="ignore"):
     elif type_str == "ndarray":
         data = np.array(node)
     elif type_str == "void":
-        # Based on https://docs.h5py.org/en/stable/strings.html?highlight=binary#how-to-store-raw-binary-data
+        # Based on https://docs.h5py.org/en/stable/strings.html#how-to-store-raw-binary-data
         data = np.void(node)
     elif type_str in ("int", "float"):
         cast = int if type_str == "int" else float

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -266,6 +266,9 @@ def _triage_write(
             sub_root = _create_titled_group(root, key, "multiarray")
             _create_titled_dataset(sub_root, "index", "ndarray", ma_index)
             _create_titled_dataset(sub_root, "data", "ndarray", ma_data)
+    elif isinstance(value, np.void):
+        # Based on https://docs.h5py.org/en/stable/strings.html?highlight=binary#how-to-store-raw-binary-data
+        _create_titled_dataset(root, key, "void", value)
     elif sparse is not None and isinstance(value, sparse.csc_matrix):
         sub_root = _create_titled_group(root, key, "csc_matrix")
         _triage_write(
@@ -527,6 +530,9 @@ def _triage_read(node, slash="ignore"):
             raise NotImplementedError("Unknown group type: {0}" "".format(type_str))
     elif type_str == "ndarray":
         data = np.array(node)
+    elif type_str == "void":
+        # Based on https://docs.h5py.org/en/stable/strings.html?highlight=binary#how-to-store-raw-binary-data
+        data = np.void(node)
     elif type_str in ("int", "float"):
         cast = int if type_str == "int" else float
         data = cast(np.array(node)[0])

--- a/h5io/tests/test_io.py
+++ b/h5io/tests/test_io.py
@@ -206,6 +206,7 @@ def test_numpy_values(tmp_path):
         np.float16,
         np.float32,
         np.float64,
+        np.void,
     ]:
         value = cast(1)
         write_hdf5(test_file, value, title="first", overwrite="update")


### PR DESCRIPTION
Add support for storing binary objects in HDF5 based on the np.void format as defined by h5py: https://docs.h5py.org/en/stable/strings.html#how-to-store-raw-binary-data