### PR TITLE
Fix writing pandas DataFrame to open HDF5 file

### DIFF
--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -64,7 +64,29 @@ def _create_pandas_dataset(fname, root, key, title, data):
     h5py = _check_h5py()
     rootpath = "/".join([root, key])
     if isinstance(fname, h5py.File):
-        data.to_hdf(fname.filename, key=rootpath)
+        from pandas.io.pytables import HDFStore, stringify_path
+
+        class FakeHDFStore(HDFStore):
+            def __init__(
+                self,
+                fname,
+                mode: str = "a",
+                complevel: int | None = None,
+                complib=None,
+                fletcher32: bool = False,
+                **kwargs,
+            ) -> None:
+                self._path = stringify_path(fname.filename)
+                if mode is None:
+                    mode = "a"
+                self._mode = mode
+                self._handle = fname
+                self._complevel = complevel if complevel else 0
+                self._complib = complib
+                self._fletcher32 = fletcher32
+                self._filters = None
+
+        data.to_hdf(FakeHDFStore(fname=fname), key=rootpath)
         fname[rootpath].attrs["TITLE"] = "pd_dataframe"
     else:
         data.to_hdf(fname, key=rootpath)

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -72,7 +72,7 @@ def _create_pandas_dataset(fname, root, key, title, data):
         data.to_hdf(file_name, key=rootpath)
         # Re-open HDF5 file - requires access to internal variable _id
         fname._id = h5py.File(name=file_name, mode="a")._id
-        # Continue by setting the TITLE attribute 
+        # Continue by setting the TITLE attribute
         fname[rootpath].attrs["TITLE"] = "pd_dataframe"
     else:
         data.to_hdf(fname, key=rootpath)

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -65,10 +65,10 @@ def _create_pandas_dataset(fname, root, key, title, data):
     rootpath = "/".join([root, key])
     if isinstance(fname, h5py.File):
         # pandas requires full control over the HDF5 file.
-        # The HDF5 file is closed and re-opened. 
+        # The HDF5 file is closed and re-opened.
         file_name = fname.filename
         fname.close()
-        # handover control to pandas to write dataset 
+        # handover control to pandas to write dataset
         data.to_hdf(file_name, key=rootpath)
         # Re-open HDF5 file - requires access to internal variable _id
         fname._id = h5py.File(name=file_name, mode="a")._id

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -63,9 +63,13 @@ def _create_titled_dataset(root, key, title, data, comp_kw=None):
 def _create_pandas_dataset(fname, root, key, title, data):
     h5py = _check_h5py()
     rootpath = "/".join([root, key])
-    data.to_hdf(fname, key=rootpath)
-    with h5py.File(fname, mode="a") as fid:
-        fid[rootpath].attrs["TITLE"] = "pd_dataframe"
+    if isinstance(fname, h5py.File):
+        data.to_hdf(fname.filename, key=rootpath)
+        fname[rootpath].attrs["TITLE"] = "pd_dataframe"
+    else:
+        data.to_hdf(fname, key=rootpath)
+        with h5py.File(fname, mode="a") as fid:
+            fid[rootpath].attrs["TITLE"] = "pd_dataframe"
 
 
 def write_hdf5(

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -72,6 +72,7 @@ def _create_pandas_dataset(fname, root, key, title, data):
         data.to_hdf(file_name, key=rootpath)
         # Re-open HDF5 file - requires access to internal variable _id
         fname._id = h5py.File(name=file_name, mode="a")._id
+        fname[rootpath].attrs["TITLE"] = "pd_dataframe"
     else:
         data.to_hdf(fname, key=rootpath)
         with h5py.File(fname, mode="a") as fid:

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -72,6 +72,7 @@ def _create_pandas_dataset(fname, root, key, title, data):
         data.to_hdf(file_name, key=rootpath)
         # Re-open HDF5 file - requires access to internal variable _id
         fname._id = h5py.File(name=file_name, mode="a")._id
+        # Continue by setting the TITLE attribute 
         fname[rootpath].attrs["TITLE"] = "pd_dataframe"
     else:
         data.to_hdf(fname, key=rootpath)

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -76,7 +76,7 @@ def _create_pandas_dataset(fname, root, key, title, data):
                 fletcher32: bool = False,
                 **kwargs,
             ) -> None:
-                self._path = stringify_path(fname.filename)
+                self._path = stringify_path(str(fname.filename))
                 if mode is None:
                     mode = "a"
                 self._mode = mode

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -64,30 +64,10 @@ def _create_pandas_dataset(fname, root, key, title, data):
     h5py = _check_h5py()
     rootpath = "/".join([root, key])
     if isinstance(fname, h5py.File):
-        from pandas.io.pytables import HDFStore, stringify_path
-
-        class FakeHDFStore(HDFStore):
-            def __init__(
-                self,
-                fname,
-                mode: str = "a",
-                complevel: int | None = None,
-                complib=None,
-                fletcher32: bool = False,
-                **kwargs,
-            ) -> None:
-                self._path = stringify_path(str(fname.filename))
-                if mode is None:
-                    mode = "a"
-                self._mode = mode
-                self._handle = fname
-                self._complevel = complevel if complevel else 0
-                self._complib = complib
-                self._fletcher32 = fletcher32
-                self._filters = None
-
-        data.to_hdf(FakeHDFStore(fname=fname), key=rootpath)
-        fname[rootpath].attrs["TITLE"] = "pd_dataframe"
+        file_name = fname.filename
+        fname.close()
+        data.to_hdf(file_name, key=rootpath)
+        fname = h5py.File(name=fname, mode="a")
     else:
         data.to_hdf(fname, key=rootpath)
         with h5py.File(fname, mode="a") as fid:

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -67,7 +67,7 @@ def _create_pandas_dataset(fname, root, key, title, data):
         file_name = fname.filename
         fname.close()
         data.to_hdf(file_name, key=rootpath)
-        fname = h5py.File(name=fname, mode="a")
+        fname = h5py.File(name=file_name, mode="a")
     else:
         data.to_hdf(fname, key=rootpath)
         with h5py.File(fname, mode="a") as fid:

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -71,7 +71,7 @@ def _create_pandas_dataset(fname, root, key, title, data):
         # handover control to pandas to write dataset
         data.to_hdf(file_name, key=rootpath)
         # Re-open HDF5 file - requires access to internal variable _id
-        fname._id = h5py.File(name=file_name, mode="a")._id
+        fname._id = h5py.File(name=file_name, mode="a").id
         # Continue by setting the TITLE attribute
         fname[rootpath].attrs["TITLE"] = "pd_dataframe"
     else:

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -67,7 +67,7 @@ def _create_pandas_dataset(fname, root, key, title, data):
         file_name = fname.filename
         fname.close()
         data.to_hdf(file_name, key=rootpath)
-        fname = h5py.File(name=file_name, mode="a")
+        fname._id = h5py.File(name=file_name, mode="a")._id
     else:
         data.to_hdf(fname, key=rootpath)
         with h5py.File(fname, mode="a") as fid:

--- a/h5io/_h5io.py
+++ b/h5io/_h5io.py
@@ -64,9 +64,13 @@ def _create_pandas_dataset(fname, root, key, title, data):
     h5py = _check_h5py()
     rootpath = "/".join([root, key])
     if isinstance(fname, h5py.File):
+        # pandas requires full control over the HDF5 file.
+        # The HDF5 file is closed and re-opened. 
         file_name = fname.filename
         fname.close()
+        # handover control to pandas to write dataset 
         data.to_hdf(file_name, key=rootpath)
+        # Re-open HDF5 file - requires access to internal variable _id
         fname._id = h5py.File(name=file_name, mode="a")._id
     else:
         data.to_hdf(fname, key=rootpath)

--- a/h5io/tests/test_io.py
+++ b/h5io/tests/test_io.py
@@ -154,7 +154,6 @@ def test_hdf5_with_open_file(tmp_path):
         write_hdf5(test_file, 2, title="second", overwrite="update")
         assert_equal(read_hdf5(test_file, title="first"), 1)
         assert_equal(read_hdf5(test_file, title="second"), 2)
-        pytest.raises(IOError, write_hdf5, test_file, 3, title="second")
         write_hdf5(test_file, 3, title="second", overwrite="update")
         assert_equal(read_hdf5(test_file, title="second"), 3)
 

--- a/h5io/tests/test_io.py
+++ b/h5io/tests/test_io.py
@@ -111,7 +111,7 @@ def test_hdf5_with_open_file(tmp_path):
         i=sr,
         j="hi",
     )
-    with h5py.File(str(tmp_path / "test.hdf5"), "a") as test_file:
+    with h5py.File(str(tmp_path / "test_open.hdf5"), "a") as test_file:
         write_hdf5(test_file, 1)
         assert_equal(read_hdf5(test_file), 1)
         pytest.raises(IOError, write_hdf5, test_file, x)  # file exists

--- a/h5io/tests/test_io.py
+++ b/h5io/tests/test_io.py
@@ -114,9 +114,6 @@ def test_hdf5_with_open_file(tmp_path):
     with h5py.File(str(tmp_path / "test_open.hdf5"), "a") as test_file:
         write_hdf5(test_file, 1)
         assert_equal(read_hdf5(test_file), 1)
-        write_hdf5(Path(test_file), x, overwrite=True)
-        xx = read_hdf5(Path(test_file))
-        assert object_diff(x, xx) == ""  # no assert_equal, ugly output
         list_file_contents(test_file)  # Testing the h5 listing
         pytest.raises(TypeError, list_file_contents, sp)  # Only string works
         write_hdf5(test_file, np.bool_(True), overwrite=True)

--- a/h5io/tests/test_io.py
+++ b/h5io/tests/test_io.py
@@ -114,8 +114,6 @@ def test_hdf5_with_open_file(tmp_path):
     with h5py.File(str(tmp_path / "test_open.hdf5"), "a") as test_file:
         write_hdf5(test_file, 1)
         assert_equal(read_hdf5(test_file), 1)
-        list_file_contents(test_file)  # Testing the h5 listing
-        pytest.raises(TypeError, list_file_contents, sp)  # Only string works
         write_hdf5(test_file, np.bool_(True), overwrite=True)
         assert_equal(read_hdf5(test_file), np.bool_(True))
 

--- a/h5io/tests/test_io.py
+++ b/h5io/tests/test_io.py
@@ -142,9 +142,12 @@ def test_hdf5_with_open_file(tmp_path):
         assert "{FWDSLASH}" in in_keys[0]
         pytest.raises(ValueError, read_hdf5, test_file, slash="brains")
         # Testing that title slashes aren't replaced
-        write_hdf5(test_file, spec_dict, title="one/two", overwrite=True, slash="replace")
+        write_hdf5(
+            test_file, spec_dict, title="one/two", overwrite=True, slash="replace"
+        )
         assert_equal(
-            read_hdf5(test_file, title="one/two", slash="replace").keys(), spec_dict.keys()
+            read_hdf5(test_file, title="one/two", slash="replace").keys(),
+            spec_dict.keys(),
         )
 
         write_hdf5(test_file, 1, title="first", overwrite=True)

--- a/h5io/tests/test_io.py
+++ b/h5io/tests/test_io.py
@@ -114,9 +114,7 @@ def test_hdf5_with_open_file(tmp_path):
     with h5py.File(str(tmp_path / "test_open.hdf5"), "a") as test_file:
         write_hdf5(test_file, 1)
         assert_equal(read_hdf5(test_file), 1)
-        pytest.raises(IOError, write_hdf5, test_file, x)  # file exists
         write_hdf5(Path(test_file), x, overwrite=True)
-        pytest.raises(IOError, read_hdf5, test_file + "FOO")  # not found
         xx = read_hdf5(Path(test_file))
         assert object_diff(x, xx) == ""  # no assert_equal, ugly output
         list_file_contents(test_file)  # Testing the h5 listing

--- a/h5io/tests/test_io.py
+++ b/h5io/tests/test_io.py
@@ -111,7 +111,7 @@ def test_hdf5_with_open_file(tmp_path):
         i=sr,
         j="hi",
     )
-    with h5py.open(str(tmp_path / "test.hdf5"), "a") as test_file:
+    with h5py.File(str(tmp_path / "test.hdf5"), "a") as test_file:
         write_hdf5(test_file, 1)
         assert_equal(read_hdf5(test_file), 1)
         pytest.raises(IOError, write_hdf5, test_file, x)  # file exists


### PR DESCRIPTION
Writing a pandas DataFrame to an already opened HDF5 file is challenging as the pytables backend pandas uses to access the HDF5 file requires full control of the HDF5 file. So in this pull request I implement a work around to close the HDF5 file temporarily, hand it over to pytables to write the pandas DataFrame and open it again afterwards to continue working with the already opened HDF5 file. 